### PR TITLE
Keep dust utxo if mixable, no matter sweeping or not

### DIFF
--- a/src/monero_transfer_utils.cpp
+++ b/src/monero_transfer_utils.cpp
@@ -288,15 +288,11 @@ void monero_transfer_utils::send_step1__prepare_params_for_get_decoys(
 			continue; // skip rct outputs if not creating rct tx
 		}
 		if (out.amount < monero_fork_rules::dust_threshold()) { // amount is dusty..
-			if (!is_sweeping) {
-//				cout << "Not sweeping, and found a dusty (though maybe mixable) output... skipping it!" << endl;
-				continue;
-			}
-			if (out.rct == none || (*out.rct).empty()) { // Sweeping, and found a dusty but unmixable (non-rct) output... skipping it!
-//				cout << "Sweeping, and found a dusty but unmixable (non-rct) output... skipping it!" << endl;
+			if (out.rct == none || (*out.rct).empty()) {
+//				cout << "Found a dusty but unmixable (non-rct) output... skipping it!" << endl;
 				continue;
 			} else {
-//				cout << "Sweeping and found a dusty but mixable (rct) amount... keeping it!" << endl;
+//				cout << "Found a dusty but mixable (rct) amount... keeping it!" << endl;
 			}
 		}
 		using_outs_amount += out.amount;


### PR DESCRIPTION
Tested with Exodus wallet, now you can spend all dust utxos.