### PR TITLE
Add estimate_fee and estimate_tx_weight

### DIFF
--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -359,6 +359,29 @@ string serial_bridge::estimate_fee(const string &args_string)
 	//
 	return ret_json_from_root(root);
 }
+string serial_bridge::estimate_tx_weight(const string &args_string)
+{
+	boost::property_tree::ptree json_root;
+	if (!parsed_json_root(args_string, json_root)) {
+		return error_ret_json_from_message("Invalid JSON");
+	}
+	//
+	bool use_rct = json_root.get<bool>("use_rct");
+	int n_inputs = stoul(json_root.get<string>("n_inputs"));
+	int mixin = stoul(json_root.get<string>("mixin"));
+	int n_outputs = stoul(json_root.get<string>("n_outputs"));
+	size_t extra_size = stoul(json_root.get<string>("extra_size"));
+	bool bulletproof = json_root.get<bool>("bulletproof");
+	//
+	uint64_t weight = monero_fee_utils::estimate_tx_weight(use_rct, n_inputs, mixin, n_outputs, extra_size, bulletproof);
+	//
+	std::ostringstream o;
+	o << weight;
+	boost::property_tree::ptree root;
+	root.put(ret_json_key__generic_retVal(), o.str());
+	//
+	return ret_json_from_root(root);
+}
 string serial_bridge::estimate_rct_tx_size(const string &args_string)
 {
 	boost::property_tree::ptree json_root;

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -329,6 +329,36 @@ string serial_bridge::estimated_tx_network_fee(const string &args_string)
 	//
 	return ret_json_from_root(root);
 }
+string serial_bridge::estimate_fee(const string &args_string)
+{
+	boost::property_tree::ptree json_root;
+	if (!parsed_json_root(args_string, json_root)) {
+		return error_ret_json_from_message("Invalid JSON");
+	}
+	//
+	bool use_per_byte_fee = json_root.get<bool>("use_per_byte_fee");
+	bool use_rct = json_root.get<bool>("use_rct");
+	int n_inputs = stoul(json_root.get<string>("n_inputs"));
+	int mixin = stoul(json_root.get<string>("mixin"));
+	int n_outputs = stoul(json_root.get<string>("n_outputs"));
+	size_t extra_size = stoul(json_root.get<string>("extra_size"));
+	bool bulletproof = json_root.get<bool>("bulletproof");
+	uint64_t base_fee = stoull(json_root.get<string>("base_fee"));
+	uint64_t fee_quantization_mask = stoull(json_root.get<string>("fee_quantization_mask"));
+	uint32_t priority = stoul(json_root.get<string>("priority"));
+	uint8_t fork_version = stoul(json_root.get<string>("fork_version"));
+	use_fork_rules_fn_type use_fork_rules_fn = monero_fork_rules::make_use_fork_rules_fn(fork_version);
+	uint64_t fee_multiplier = monero_fee_utils::get_fee_multiplier(priority, monero_fee_utils::default_priority(), monero_fee_utils::get_fee_algorithm(use_fork_rules_fn), use_fork_rules_fn);
+	//
+	uint64_t fee = monero_fee_utils::estimate_fee(use_per_byte_fee, use_rct, n_inputs, mixin, n_outputs, extra_size, bulletproof, base_fee, fee_multiplier, fee_quantization_mask);
+	//
+	std::ostringstream o;
+	o << fee;
+	boost::property_tree::ptree root;
+	root.put(ret_json_key__generic_retVal(), o.str());
+	//
+	return ret_json_from_root(root);
+}
 string serial_bridge::estimate_rct_tx_size(const string &args_string)
 {
 	boost::property_tree::ptree json_root;

--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -62,6 +62,7 @@ namespace serial_bridge
 	string validate_components_for_login(const string &args_string);
 	//
 	string estimated_tx_network_fee(const string &args_string);
+	string estimate_fee(const string &args_string);
 	string estimate_rct_tx_size(const string &args_string);
 	//
 	string generate_key_image(const string &args_string);

--- a/src/serial_bridge_index.hpp
+++ b/src/serial_bridge_index.hpp
@@ -63,6 +63,7 @@ namespace serial_bridge
 	//
 	string estimated_tx_network_fee(const string &args_string);
 	string estimate_fee(const string &args_string);
+	string estimate_tx_weight(const string &args_string);
 	string estimate_rct_tx_size(const string &args_string);
 	//
 	string generate_key_image(const string &args_string);

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -931,6 +931,34 @@ BOOST_AUTO_TEST_CASE(bridged__estimate_fee)
 	BOOST_REQUIRE(fee == 330050000);
 	cout << "bridged__estimate_fee: " << fee << endl;
 }
+BOOST_AUTO_TEST_CASE(bridged__estimate_tx_weight)
+{
+	using namespace serial_bridge;
+	//
+	boost::property_tree::ptree root;
+	root.put("use_rct", "true");
+	root.put("n_inputs", "2");
+	root.put("mixin", "10");
+	root.put("n_outputs", "2");
+	root.put("extra_size", "0");
+	root.put("bulletproof", "true");
+	//
+	auto ret_string = serial_bridge::estimate_tx_weight(args_string_from_root(root));
+	stringstream ret_stream;
+	ret_stream << ret_string;
+	boost::property_tree::ptree ret_tree;
+	boost::property_tree::read_json(ret_stream, ret_tree);
+	optional<string> err_string = ret_tree.get_optional<string>(ret_json_key__any__err_msg());
+	if (err_string != none) {
+		BOOST_REQUIRE_MESSAGE(false, *err_string);
+	}
+	optional<string> weight_string = ret_tree.get_optional<string>(ret_json_key__generic_retVal());
+	BOOST_REQUIRE(weight_string != none);
+	BOOST_REQUIRE((*weight_string).size() > 0);
+	uint64_t weight = stoull(*weight_string);
+	BOOST_REQUIRE(weight == 2677);
+	cout << "bridged__estimate_tx_weight: " << weight << endl;
+}
 BOOST_AUTO_TEST_CASE(bridged__estimate_rct_tx_size)
 {
 	using namespace serial_bridge;

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -898,6 +898,39 @@ BOOST_AUTO_TEST_CASE(bridged__estimated_tx_network_fee)
 	BOOST_REQUIRE(fee == 330047330);
 	cout << "bridged__estimated_tx_network_fee: " << fee << endl;
 }
+BOOST_AUTO_TEST_CASE(bridged__estimate_fee)
+{
+	using namespace serial_bridge;
+	//
+	boost::property_tree::ptree root;
+	root.put("use_per_byte_fee", "true");
+	root.put("use_rct", "true");
+	root.put("n_inputs", "2");
+	root.put("mixin", "10");
+	root.put("n_outputs", "2");
+	root.put("extra_size", "0");
+	root.put("bulletproof", "true");
+	root.put("base_fee", "24658");
+	root.put("fee_quantization_mask", "10000");
+	root.put("priority", "2");
+	root.put("fork_version", "10");
+	//
+	auto ret_string = serial_bridge::estimate_fee(args_string_from_root(root));
+	stringstream ret_stream;
+	ret_stream << ret_string;
+	boost::property_tree::ptree ret_tree;
+	boost::property_tree::read_json(ret_stream, ret_tree);
+	optional<string> err_string = ret_tree.get_optional<string>(ret_json_key__any__err_msg());
+	if (err_string != none) {
+		BOOST_REQUIRE_MESSAGE(false, *err_string);
+	}
+	optional<string> fee_string = ret_tree.get_optional<string>(ret_json_key__generic_retVal());
+	BOOST_REQUIRE(fee_string != none);
+	BOOST_REQUIRE((*fee_string).size() > 0);
+	uint64_t fee = stoull(*fee_string);
+	BOOST_REQUIRE(fee == 330050000);
+	cout << "bridged__estimate_fee: " << fee << endl;
+}
 BOOST_AUTO_TEST_CASE(bridged__estimate_rct_tx_size)
 {
 	using namespace serial_bridge;


### PR DESCRIPTION
- `estimate_fee` is used in `send_step1__prepare_params_for_get_decoys`, which is more accurate and flexiable than `estimated_tx_network_fee`.
- `estimate_tx_weight` is used in `estimate_fee`, more accurate than `estimate_rct_tx_size`.