### PR TITLE
updated handling to be in accordance with Monero hard fork v15: chang…

### DIFF
--- a/src/monero_fork_rules.cpp
+++ b/src/monero_fork_rules.cpp
@@ -59,7 +59,7 @@ bool monero_fork_rules::lightwallet_hardcoded__use_fork_rules(uint8_t version, i
 // Protocol / Defaults
 uint32_t monero_fork_rules::fixed_ringsize()
 {
-	return 11; // v8
+	return 16; // v15
 }
 uint32_t monero_fork_rules::fixed_mixinsize()
 {

--- a/src/monero_transfer_utils.cpp
+++ b/src/monero_transfer_utils.cpp
@@ -563,7 +563,10 @@ void monero_transfer_utils::create_transaction(
 	uint32_t fake_outputs_count = fixed_mixinsize();
 	rct::RangeProofType range_proof_type = rct::RangeProofPaddedBulletproof;
 	int bp_version = 1;
-	if (use_fork_rules_fn(HF_VERSION_CLSAG, -10)) {
+	if (use_fork_rules_fn(HF_VERSION_BULLETPROOF_PLUS, -10)) {
+		bp_version = 4;
+	}
+	else if (use_fork_rules_fn(HF_VERSION_CLSAG, -10)) {
 		bp_version = 3;
 	}
 	else if (use_fork_rules_fn(HF_VERSION_SMALLER_BP, -10)) {
@@ -776,9 +779,8 @@ void monero_transfer_utils::create_transaction(
 		sender_account_keys, subaddresses,
 		sources, splitted_dsts, change_dst.addr, extra,
 		tx, unlock_time, tx_key, additional_tx_keys,
-		true, rct_config,
-		/*m_multisig ? &msout : */NULL
-	);
+		true, rct_config, true);
+
 	LOG_PRINT_L2("constructed tx, r="<<r);
 	if (!r) {
 		// TODO: return error::tx_not_constructed, sources, dsts, unlock_time, nettype
@@ -790,7 +792,7 @@ void monero_transfer_utils::create_transaction(
 		retVals.errCode = transactionTooBig;
 		return;
 	}
-	bool use_bulletproofs = !tx.rct_signatures.p.bulletproofs.empty();
+	bool use_bulletproofs = !tx.rct_signatures.p.bulletproofs_plus.empty();
 	THROW_WALLET_EXCEPTION_IF(use_bulletproofs != true, error::wallet_internal_error, "Expected tx use_bulletproofs to equal bulletproof flag");
 	//
 	retVals.tx = tx;

--- a/src/serial_bridge_index.cpp
+++ b/src/serial_bridge_index.cpp
@@ -801,6 +801,8 @@ string serial_bridge::decodeRct(const string &args_string)
 		rv.type = rct::RCTTypeBulletproof2;
 	} else if (rv_type_int == rct::RCTTypeCLSAG) {
 		rv.type = rct::RCTTypeCLSAG;
+	} else if (rv_type_int == rct::RCTTypeBulletproofPlus) {
+		rv.type = rct::RCTTypeBulletproofPlus;
 	} else {
 		return error_ret_json_from_message("Invalid 'rv.type'");
 	}
@@ -876,6 +878,8 @@ string serial_bridge::decodeRctSimple(const string &args_string)
 		rv.type = rct::RCTTypeBulletproof2;
 	} else if (rv_type_int == rct::RCTTypeCLSAG) {
 		rv.type = rct::RCTTypeCLSAG;
+	} else if (rv_type_int == rct::RCTTypeBulletproofPlus) {
+		rv.type = rct::RCTTypeBulletproofPlus;
 	} else {
 		return error_ret_json_from_message("Invalid 'rv.type'");
 	}


### PR DESCRIPTION
updated handling to be in accordance with Monero hard fork v15: changed fixed ring size from 11 to 16, added handling for bp_version = 4 to represent bulletproof plus, and in call to construct_tx_and_get_tx_key passed in true for variable representing use_view_tags